### PR TITLE
fix: action fails if event body is null

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,16 +12,22 @@ runs:
         import json
         import re
         import os
-        with open('${{ github.event_path }}') as fh:
+        with open('') as fh:
             event = json.load(fh)
+        print (f'Review.Body:\n{event["review"]["body"]}')
+        # if the event.review.body is not null
         # filter out any quote-reply content, i.e. lines that start with ">"
-        newComments = re.sub("^>.*$", "", event['review']['body'], 0, re.M)
-        qaMention = 1 if "QA_TEST" in newComments else 0
-        # JSON-escaped, but strip the start and end quote marks that json.dumps includes
-        escapedTitle = json.dumps(event['pull_request']['title'])[1:-1]
-        with open(os.environ['GITHUB_ENV'], 'a') as fh:
-            print(f'PR_TITLE={escapedTitle}', file=fh)
-            print(f'qa_mention={qaMention}', file=fh)
+        if event['review']['body'] is not None:
+          newComments = re.sub("^>.*$", "", event['review']['body'], 0, re.M)
+          qaMention = 1 if "QA_TEST" in newComments else 0
+          # JSON-escaped, but strip the start and end quote marks that json.dumps includes
+          escapedTitle = json.dumps(event['pull_request']['title'])[1:-1]
+          with open(os.environ['GITHUB_ENV'], 'a') as fh:
+              print(f'PR_TITLE={escapedTitle}', file=fh)
+              print(f'qa_mention={qaMention}', file=fh)
+        else:
+          with open(os.environ['GITHUB_ENV'], 'a') as fh:
+              print(f'qa_mention={0}', file=fh)
       shell: python
 
     - name: Cancel if no QA Mention


### PR DESCRIPTION
The github action hook triggering this action will potentially send an event with a body set to 'null'. when this happens, the event fails on this line: 'newComments = re.sub(^