### PR TITLE
fix: open statement in python script

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,9 +12,8 @@ runs:
         import json
         import re
         import os
-        with open('') as fh:
+        with open('${{ github.event_path }}') as fh:
             event = json.load(fh)
-        print (f'Review.Body:\n{event["review"]["body"]}')
         # if the event.review.body is not null
         # filter out any quote-reply content, i.e. lines that start with ">"
         if event['review']['body'] is not None:


### PR DESCRIPTION
Fixing errors like [this one](https://github.com/byu-oit/ios-byuSuite/actions/runs/9116367530/job/25064815640): 

> Traceback (most recent call last):
 > File "/home/runner/work/_temp/899577ea-8bef-479c-87ca-483b0f8cde44.py", line 4, in <module> with open('') as fh:
> FileNotFoundError: [Errno 2] No such file or directory: ''